### PR TITLE
exclude nans channels from check for nans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - conda install conda-build anaconda-client pytest pytest-cov
   - conda build . --no-test -c pyomeca
   - cd ..
-  - conda install --use-local pyomeca -c pyomeca
+  - conda install --use-local pyomeca -c pyomeca -c conda-forge
   - conda info -a
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ install:
   - cd conda.recipe
   - conda build . --no-test -c pyomeca
   - cd ..
-  - conda install --use-local pyomeca -c pyomeca
+  - conda install --use-local pyomeca -c pyomeca -c conda-forge
   - conda info -a
 
 

--- a/pyomeca/frame_dependent.py
+++ b/pyomeca/frame_dependent.py
@@ -39,7 +39,7 @@ class FrameDependentNpArray(np.ndarray):
             self.get_rate = []
             self.get_labels = []
             self.get_unit = []
-            self.get_nan_idx = []
+            self.get_nan_idx = None
             self.misc = {}
         else:
             self._current_frame = getattr(obj, '_current_frame')

--- a/pyomeca/frame_dependent.py
+++ b/pyomeca/frame_dependent.py
@@ -17,7 +17,7 @@ class FrameDependentNpArray(np.ndarray):
         Parameters
         ----------
         array : np.ndarray
-            A 3 dimensions matrix where 3rd dimension is the frame
+            A 3-dimensions matrix where 3rd dimension is the frame
         -------
 
         """


### PR DESCRIPTION
## Proposed changes

We have a function to ensure that the user does not send channels containing nans in our signal processing functions (`check_for_nans`). I just added a quick fix to exclude channels that are tagged as nans from the function described above.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
