### PR TITLE
made the possibility to load non_existing data from a c3d (put in nan)

### DIFF
--- a/pyomeca/frame_dependent.py
+++ b/pyomeca/frame_dependent.py
@@ -561,7 +561,7 @@ class FrameDependentNpArray(np.ndarray):
                 for itarget in target_names:
                     try:
                         idx.append(all_names.index(itarget))
-                    except:
+                    except ValueError:
                         idx.append(-1)  # Watch out, this will read the last column!
             else:
                 idx = [all_names.index(itarget) for itarget in target_names]

--- a/pyomeca/frame_dependent.py
+++ b/pyomeca/frame_dependent.py
@@ -494,7 +494,9 @@ class FrameDependentNpArray(np.ndarray):
         raise NotImplementedError("_parse_c3d_info is an abstract function")
 
     @classmethod
-    def from_c3d(cls, filename, idx=None, names=None, ignore_non_present_names=False, prefix=None):
+    def from_c3d(
+        cls, filename, idx=None, names=None, ignore_non_present_names=False, prefix=None
+    ):
         """
         Read c3d data and convert to Vectors3d format
         Parameters
@@ -544,7 +546,15 @@ class FrameDependentNpArray(np.ndarray):
         )
 
     @classmethod
-    def _to_vectors(cls, data, idx, all_names, target_names, metadata=None, ignore_non_present_names=False):
+    def _to_vectors(
+        cls,
+        data,
+        idx,
+        all_names,
+        target_names,
+        metadata=None,
+        ignore_non_present_names=False,
+    ):
         if not idx:
             if ignore_non_present_names:
                 idx = []


### PR DESCRIPTION
This capability may be controversial since it silences potential errors. That is why I made it optional and non default. 

If you put the tag to True, then the C3D will read even though you requested non existing names in the C3D file. The corresponding columns will be fill with nans

If you are against this fix, please fill free to reject it