### PR TITLE
Update conda-package.yml

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Add path DLL to windows path (windows only)
         if: startsWith(matrix.os, 'windows')
-        run: echo "##[add-path]C:\Miniconda\Library\bin"
+        run: echo "C:\Miniconda\Library\bin" >> $GITHUB_PATH
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
The `add-path` command is now disabled in github actions which caused an error during the build process.
I just updated the command with the instructions find [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).