### PR TITLE
Fix numpy issue with windows

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python
-  - numpy > 1.18
+  - numpy
   - scipy
   - xarray
   - ezc3d >= 1.3.2


### PR DESCRIPTION
This PR fix an issue found in the [windows CI](https://github.com/pyomeca/pyomeca/runs/2813946356?check_suite_focus=true) reached during the installation process.