### PR TITLE
 Fix file-reading for files with no analog data

### DIFF
--- a/pyomeca/io/read.py
+++ b/pyomeca/io/read.py
@@ -49,6 +49,16 @@ def read_c3d(
     data_by_frame = 1 if group == "POINT" else reader.header().nbAnalogByFrame()
 
     attrs = attrs if attrs else {}
+
+    if data_by_frame == 0:
+        empty_time = np.array([], dtype=float)
+        return caller(
+            data[0, ...] if group == "ANALOG" else data,
+            channels,
+            time=empty_time,
+            attrs=attrs,
+        )
+
     attrs["first_frame"] = reader.header().firstFrame() * data_by_frame
     attrs["last_frame"] = reader.header().lastFrame() * data_by_frame
     attrs["rate"] = reader.header().frameRate() * data_by_frame


### PR DESCRIPTION
Prevent crashes if a data is unavailable (faced when reading files from Optitrack Motive 3.4.4 exported to .c3d without ANALOG data)